### PR TITLE
Add support for brightness, contrast, and saturation filters

### DIFF
--- a/public_html/locale/en.json
+++ b/public_html/locale/en.json
@@ -41,6 +41,7 @@
     "cropform-aspect-ratio-fixed": "Custom",
     "cropform-brightness": "Brightness",
     "cropform-contrast": "Contrast",
+    "cropform-saturation": "Saturation",
     "cropping-progress": "Please wait while cropping...",
     "previewform-lossless": "A lossless crop was performed.",
     "previewform-lossless-explanation": "The resulting image is {{wider}} px wider and {{higher}} px higher than the region you selected. <a target=\"_blank\" href=\"{{url}}\">Why?<\/a> Note that the extra pixels included are in the left and\/or top part of the image.",

--- a/public_html/locale/en.json
+++ b/public_html/locale/en.json
@@ -39,6 +39,8 @@
     "cropform-aspect-ratio-free": "Free",
     "cropform-aspect-ratio-keep": "Keep",
     "cropform-aspect-ratio-fixed": "Custom",
+    "cropform-brightness": "Brightness",
+    "cropform-contrast": "Contrast",
     "cropping-progress": "Please wait while cropping...",
     "previewform-lossless": "A lossless crop was performed.",
     "previewform-lossless-explanation": "The resulting image is {{wider}} px wider and {{higher}} px higher than the region you selected. <a target=\"_blank\" href=\"{{url}}\">Why?<\/a> Note that the extra pixels included are in the left and\/or top part of the image.",

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -176,3 +176,7 @@ Some people complain about contrast of system cursor */
 html .cropper-crop {
   cursor: url( '../res/crosshair.png' ) 16 16, crosshair;
 }
+/* Needed to prevent the overlay color from affecting the preview */
+html .cropper-face {
+  background-color: unset;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -293,6 +293,14 @@
                             <input ng-if="cropmethod === 'precise'" type="number" ng-model="rotation.angle" step="0.01">
                             <input ng-if="cropmethod === 'lossless'" type="range" ng-input-range ng-model="rotation.angle" min="0" step="90" max="270">
                         </label>
+                        <label ng-if="metadata.supportsFilters && cropmethod !== 'lossless'">
+                            {{ 'cropform-brightness' | translate }}
+                            <input type="number" ng-model="filters.brightness" min="-100" max="100" step="0.01">
+                        </label>
+                        <label ng-if="metadata.supportsFilters && cropmethod !== 'lossless'">
+                            {{ 'cropform-contrast' | translate }}
+                            <input type="number" ng-model="filters.contrast" min="-100" max="100" step="0.01">
+                        </label>
                     </div>
 
                     <div style="margin-bottom:.8em;">

--- a/src/index.html
+++ b/src/index.html
@@ -301,6 +301,10 @@
                             {{ 'cropform-contrast' | translate }}
                             <input type="number" ng-model="filters.contrast" min="-100" max="100" step="0.01">
                         </label>
+                        <label ng-if="metadata.supportsFilters && cropmethod !== 'lossless'">
+                            {{ 'cropform-saturation' | translate }}
+                            <input type="number" ng-model="filters.saturation" min="-100" max="100" step="0.01">
+                        </label>
                     </div>
 
                     <div style="margin-bottom:.8em;">
@@ -547,12 +551,13 @@
 </footer>
 
 <svg width="0" height="0" style="position:absolute">
-  <filter id="brightness-contrast-filter" color-interpolation-filters="sRGB">
+  <filter id="crop-filter" color-interpolation-filters="sRGB">
     <feComponentTransfer>
       <feFuncR type="linear" slope="1" intercept="0"/>
       <feFuncG type="linear" slope="1" intercept="0"/>
       <feFuncB type="linear" slope="1" intercept="0"/>
     </feComponentTransfer>
+    <feColorMatrix type="saturate" values="1.0"/>
   </filter>
 </svg>
 

--- a/src/index.html
+++ b/src/index.html
@@ -546,6 +546,16 @@
   </span>
 </footer>
 
+<svg width="0" height="0" style="position:absolute">
+  <filter id="brightness-contrast-filter" color-interpolation-filters="sRGB">
+    <feComponentTransfer>
+      <feFuncR type="linear" slope="1" intercept="0"/>
+      <feFuncG type="linear" slope="1" intercept="0"/>
+      <feFuncB type="linear" slope="1" intercept="0"/>
+    </feComponentTransfer>
+  </filter>
+</svg>
+
 </body>
 
 </html>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -283,6 +283,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
         $scope.busy = true;
         $scope.crop_dim = undefined;
         $scope.rotation = {angle: 0};
+        $scope.filters = {brightness: 0, contrast: 0};
 
         $http.get('./api/file/info?' + $httpParamSerializer({
             title: $scope.currentUrlParams.title,
@@ -426,6 +427,8 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
             $scope.rotation.angle += 360;
         }
         $scope.rotation.angle = Math.round($scope.rotation.angle / 90) * 90;
+        $scope.filters.brightness = 0;
+        $scope.filters.contrast = 0;
     };
 
     function getAspectRatio() {
@@ -569,7 +572,9 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
             y: $scope.crop_dim.y,
             rotate: $scope.crop_dim.rotate,
             width: $scope.crop_dim.w,
-            height: $scope.crop_dim.h
+            height: $scope.crop_dim.h,
+            brightness: $scope.filters.brightness,
+            contrast: $scope.filters.contrast
         }))
         .then(function(res) {
             var response = res.data;
@@ -684,6 +689,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
     $scope.aspectratio_cy = LocalStorageService.get('croptool-aspectratio-y') || '9';;
     $scope.overwrite = LocalStorageService.get('croptool-overwrite') || 'overwrite';;
     $scope.rotation = {angle: 0};
+    $scope.filters = {brightness: 0, contrast: 0};
     $scope.aspectRatioChanged();
 
     // On filename change, check with the MediaWiki API if the file exists.

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -288,7 +288,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
         $scope.busy = true;
         $scope.crop_dim = undefined;
         $scope.rotation = {angle: 0};
-        $scope.filters = {brightness: 0, contrast: 0};
+        $scope.filters = {brightness: 0, contrast: 0, saturation: 0};
 
         $http.get('./api/file/info?' + $httpParamSerializer({
             title: $scope.currentUrlParams.title,
@@ -434,6 +434,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
         $scope.rotation.angle = Math.round($scope.rotation.angle / 90) * 90;
         $scope.filters.brightness = 0;
         $scope.filters.contrast = 0;
+        $scope.filters.saturation = 0;
     };
 
     function getAspectRatio() {
@@ -579,7 +580,8 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
             width: $scope.crop_dim.w,
             height: $scope.crop_dim.h,
             brightness: $scope.filters.brightness,
-            contrast: $scope.filters.contrast
+            contrast: $scope.filters.contrast,
+            saturation: $scope.filters.saturation
         }))
         .then(function(res) {
             var response = res.data;
@@ -694,7 +696,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
     $scope.aspectratio_cy = LocalStorageService.get('croptool-aspectratio-y') || '9';;
     $scope.overwrite = LocalStorageService.get('croptool-overwrite') || 'overwrite';;
     $scope.rotation = {angle: 0};
-    $scope.filters = {brightness: 0, contrast: 0};
+    $scope.filters = {brightness: 0, contrast: 0, saturation: 0};
     $scope.aspectRatioChanged();
 
     /**
@@ -716,17 +718,22 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
      * to apply the filter instead of a regular CSS filter since CSS filters
      * are multiplicative, not additive like ImageMagick.
      */
-    function updateFilters(brightness, contrast) {
+    function updateFilters(brightness, contrast, saturation) {
         var slope = contrast >= 0
             ? 100.0 * safeReciprocal(100.0 - contrast)
             : 0.01 * contrast + 1.0;
         var intercept = (0.01 * brightness - 0.5) * slope + 0.5;
 
-        var transfer = document.querySelector('#brightness-contrast-filter feComponentTransfer');
+        var transfer = document.querySelector('#crop-filter feComponentTransfer');
         var funcs = transfer ? transfer.children : [];
         for (var i = 0; i < funcs.length; i++) {
             funcs[i].setAttribute('slope', slope);
             funcs[i].setAttribute('intercept', intercept);
+        }
+
+        var matrix = document.querySelector('#crop-filter feColorMatrix');
+        if (matrix) {
+            matrix.setAttribute('values', 1.0 + saturation / 100.0);
         }
     }
 
@@ -734,9 +741,10 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
         // Clamping is needed since input validation is only advisory.
         var brightness = Math.max(-100, Math.min(100, $scope.filters.brightness || 0));
         var contrast = Math.max(-100, Math.min(100, $scope.filters.contrast || 0));
-        var filterValue = (brightness || contrast) ? 'url(#brightness-contrast-filter)' : '';
+        var saturation = Math.max(-100, Math.min(100, $scope.filters.saturation || 0));
+        var filterValue = (brightness || contrast || saturation) ? 'url(#crop-filter)' : '';
 
-        updateFilters(brightness, contrast);
+        updateFilters(brightness, contrast, saturation);
 
         var images = document.querySelectorAll('.cropper-crop-box img');
         for (var i = 0; i < images.length; i++) {
@@ -744,7 +752,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
         }
     }
 
-    $scope.$watchGroup(['filters.brightness', 'filters.contrast'], applyFilters);
+    $scope.$watchGroup(['filters.brightness', 'filters.contrast', 'filters.saturation'], applyFilters);
     $scope.$on('cropper-ready', applyFilters);
 
     // On filename change, check with the MediaWiki API if the file exists.

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -121,6 +121,11 @@ directive('ctCropper', ['$timeout', function($timeout) {
                     aspectRatio: scope.aspectRatio,
                     crop: cropperCrop,
 
+                    // Needed to apply filters when re-initializing cropper.
+                    ready: function() {
+                        scope.$emit('cropper-ready');
+                    },
+
                     // restrict cropbox to size of canvas, and restrict canvas
                     // to fit within container
                     viewMode: 2,
@@ -691,6 +696,56 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
     $scope.rotation = {angle: 0};
     $scope.filters = {brightness: 0, contrast: 0};
     $scope.aspectRatioChanged();
+
+    /**
+     * Adapted from MagickSafeReciprocal in ImageMagick (MagickCore/statistic-private.h).
+     *
+     * License: https://imagemagick.org/script/license.php
+     */
+    function safeReciprocal(value) {
+        if (Math.abs(value) < 1e-15) {
+            return 1e15;
+        }
+        return 1.0 / value;
+    }
+
+    /**
+     * Approximates the brightness/contrast filter used by ImageMagick.
+     *
+     * This approximation isn't perfect, but it's pretty close. An SVG is used
+     * to apply the filter instead of a regular CSS filter since CSS filters
+     * are multiplicative, not additive like ImageMagick.
+     */
+    function updateFilters(brightness, contrast) {
+        var slope = contrast >= 0
+            ? 100.0 * safeReciprocal(100.0 - contrast)
+            : 0.01 * contrast + 1.0;
+        var intercept = (0.01 * brightness - 0.5) * slope + 0.5;
+
+        var transfer = document.querySelector('#brightness-contrast-filter feComponentTransfer');
+        var funcs = transfer ? transfer.children : [];
+        for (var i = 0; i < funcs.length; i++) {
+            funcs[i].setAttribute('slope', slope);
+            funcs[i].setAttribute('intercept', intercept);
+        }
+    }
+
+    function applyFilters() {
+        // Clamping is needed since input validation is only advisory.
+        var brightness = Math.max(-100, Math.min(100, $scope.filters.brightness || 0));
+        var contrast = Math.max(-100, Math.min(100, $scope.filters.contrast || 0));
+        var filterValue = (brightness || contrast) ? 'url(#brightness-contrast-filter)' : '';
+
+        updateFilters(brightness, contrast);
+
+        var images = document.querySelectorAll('.cropper-crop-box img');
+        for (var i = 0; i < images.length; i++) {
+            images[i].style.filter = filterValue;
+        }
+    }
+
+    $scope.$watchGroup(['filters.brightness', 'filters.contrast'], applyFilters);
+    $scope.$on('cropper-ready', applyFilters);
 
     // On filename change, check with the MediaWiki API if the file exists.
     // Delay 500 ms before checking in case the user is in the process of typing.

--- a/src/php/Controllers/FileController.php
+++ b/src/php/Controllers/FileController.php
@@ -118,6 +118,7 @@ class FileController
         $rotation = floatval($request->getQueryParams()['rotate'] ?? 0);
         $brightness = max(-100.0, min(100.0, floatval($request->getQueryParams()['brightness'] ?? 0)));
         $contrast = max(-100.0, min(100.0, floatval($request->getQueryParams()['contrast'] ?? 0)));
+        $saturation = max(-100.0, min(100.0, floatval($request->getQueryParams()['saturation'] ?? 0)));
         $cropMethod = $request->getQueryParams()['method'] ??'precise';
 
         $t0 = microtime(true) * 1000;
@@ -133,7 +134,7 @@ class FileController
         }
 
         $original = $editor->open($page->file, $pageno);
-        $crop = $original->crop($destPath, $cropMethod, $x, $y, $width, $height, $rotation, $brightness, $contrast);
+        $crop = $original->crop($destPath, $cropMethod, $x, $y, $width, $height, $rotation, $brightness, $contrast, $saturation);
         $thumb = $crop->thumb($thumbPath);
 
         $logger->info('[{sha1}] Cropped using {method} mode', [
@@ -163,6 +164,9 @@ class FileController
         }
         if ($contrast != 0) {
             $dim[] = "contrast {$contrast}";
+        }
+        if ($saturation != 0) {
+            $dim[] = "saturation {$saturation}";
         }
 
         $options = $page->wikitext->possibleStuffToRemove();

--- a/src/php/Controllers/FileController.php
+++ b/src/php/Controllers/FileController.php
@@ -86,6 +86,7 @@ class FileController
             'orientation' => $original->orientation,
             'categories' => $page->imageinfo->categories,
             'supportsRotation' => $page->file->supportsRotation(),
+            'supportsFilters' => $page->file->supportsFilters(),
             'overrideResultExtension' => $page->file->overrideResultExtension()
         ]));
 
@@ -115,6 +116,8 @@ class FileController
         $width = intval($request->getQueryParams()['width'] ?? 0);
         $height = intval($request->getQueryParams()['height'] ?? 0);
         $rotation = floatval($request->getQueryParams()['rotate'] ?? 0);
+        $brightness = max(-100.0, min(100.0, floatval($request->getQueryParams()['brightness'] ?? 0)));
+        $contrast = max(-100.0, min(100.0, floatval($request->getQueryParams()['contrast'] ?? 0)));
         $cropMethod = $request->getQueryParams()['method'] ??'precise';
 
         $t0 = microtime(true) * 1000;
@@ -130,7 +133,7 @@ class FileController
         }
 
         $original = $editor->open($page->file, $pageno);
-        $crop = $original->crop($destPath, $cropMethod, $x, $y, $width, $height, $rotation);
+        $crop = $original->crop($destPath, $cropMethod, $x, $y, $width, $height, $rotation, $brightness, $contrast);
         $thumb = $crop->thumb($thumbPath);
 
         $logger->info('[{sha1}] Cropped using {method} mode', [
@@ -154,6 +157,12 @@ class FileController
         $dim[] = ($cropPercentXY ?: ' < 1') . '% areawise';
         if ($rotation) {
             $dim[] = "rotated {$rotation}°";
+        }
+        if ($brightness != 0) {
+            $dim[] = "brightness {$brightness}";
+        }
+        if ($contrast != 0) {
+            $dim[] = "contrast {$contrast}";
         }
 
         $options = $page->wikitext->possibleStuffToRemove();

--- a/src/php/File/File.php
+++ b/src/php/File/File.php
@@ -187,7 +187,7 @@ class File implements FileInterface
         ];
     }
 
-    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast, $saturation)
     {
         $image = new Imagick($srcPath);
 
@@ -198,8 +198,29 @@ class File implements FileInterface
         }
         $image->cropImage($coords['width'], $coords['height'], $coords['x'], $coords['y']);
         $image->setImagePage(0, 0, 0, 0);  // Reset virtual canvas, like +repage
+
         // Apply brightness/contrast to RGB channels only, not alpha
         $image->brightnessContrastImage($brightness, $contrast, \Imagick::CHANNEL_ALL & ~\Imagick::CHANNEL_ALPHA);
+
+        // Uses a color matrix instead of Imagick::modulateImage for saturation
+        // to match the SVG feColorMatrix saturate preview used in the
+        // frontend. HSL modulation computes luminance from min/max of RGB
+        // channels, which discards color noise differently.
+        //
+        // https://www.w3.org/TR/filter-effects-1/#feColorMatrixElement
+        if ($saturation != 0) {
+            $s = 1.0 + $saturation / 100.0;
+
+            // 5x5 RGBKA matrix. Imagick requires 5x5 or 6x6 with PHP bindings
+            $image->colorMatrixImage([
+                0.213 + 0.787 * $s, 0.715 - 0.715 * $s, 0.072 - 0.072 * $s, 0, 0,
+                0.213 - 0.213 * $s, 0.715 + 0.285 * $s, 0.072 - 0.072 * $s, 0, 0,
+                0.213 - 0.213 * $s, 0.715 - 0.715 * $s, 0.072 + 0.928 * $s, 0, 0,
+                0,                  0,                  0,                  1, 0,
+                0,                  0,                  0,                  0, 1,
+            ]);
+        }
+
         static::saveImage($image, $destPath, $srcPath);
         $image->destroy();
     }

--- a/src/php/File/File.php
+++ b/src/php/File/File.php
@@ -187,7 +187,7 @@ class File implements FileInterface
         ];
     }
 
-    public function crop($srcPath, $destPath, $method, $coords, $rotation)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast)
     {
         $image = new Imagick($srcPath);
 
@@ -198,6 +198,8 @@ class File implements FileInterface
         }
         $image->cropImage($coords['width'], $coords['height'], $coords['x'], $coords['y']);
         $image->setImagePage(0, 0, 0, 0);  // Reset virtual canvas, like +repage
+        // Apply brightness/contrast to RGB channels only, not alpha
+        $image->brightnessContrastImage($brightness, $contrast, \Imagick::CHANNEL_ALL & ~\Imagick::CHANNEL_ALPHA);
         static::saveImage($image, $destPath, $srcPath);
         $image->destroy();
     }
@@ -208,6 +210,10 @@ class File implements FileInterface
     }
 
     public function supportsRotation() {
+        return true;
+    }
+
+    public function supportsFilters() {
         return true;
     }
 

--- a/src/php/File/FileInterface.php
+++ b/src/php/File/FileInterface.php
@@ -16,11 +16,13 @@ interface FileInterface
 
     static public function readMetadata($path);
 
-    public function crop($srcPath, $destPath, $method, $coords, $rotation);
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast);
 
     static public function saveImage($im, $destPath, $srcPath);
 
     public function supportsRotation();
+
+    public function supportsFilters();
 
     public function overrideResultExtension();
 }

--- a/src/php/File/FileInterface.php
+++ b/src/php/File/FileInterface.php
@@ -16,7 +16,7 @@ interface FileInterface
 
     static public function readMetadata($path);
 
-    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast);
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast, $saturation);
 
     static public function saveImage($im, $destPath, $srcPath);
 

--- a/src/php/File/GifFile.php
+++ b/src/php/File/GifFile.php
@@ -6,17 +6,29 @@ use pastuhov\Command\Command;
 
 class GifFile extends File implements FileInterface
 {
-    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast, $saturation)
     {
         $dim = $coords['width'] . 'x' . $coords['height'] . '+' . $coords['x'] .'+' . $coords['y'] . '!';
-
         $rotate = $rotation ? '-rotate ' . intval($rotation) . ' +repage' : '';
 
-        Command::exec('convert {src} ' . $rotate . ' -crop {dim} -channel RGB -brightness-contrast {bc} {dest}', [
+        // Uses a color matrix instead of Imagick::modulateImage for saturation
+        // to match the SVG feColorMatrix saturate preview used in the
+        // frontend. HSL modulation computes luminance from min/max of RGB
+        // channels, which discards color noise differently.
+        //
+        // https://www.w3.org/TR/filter-effects-1/#feColorMatrixElement
+        $colorMatrix = $saturation != 0 ? '-color-matrix {cm}' : '';
+        $s = 1.0 + $saturation / 100.0;
+
+        Command::exec('convert {src} ' . $rotate . ' -crop {dim} -channel RGB -brightness-contrast {bc} ' . $colorMatrix . ' {dest}', [
             'src' => $srcPath,
             'dest' => $destPath,
             'dim' => $dim,
             'bc' => $brightness . 'x' . $contrast,
+            'cm' => '3x3:'
+                . (0.213 + 0.787 * $s) . ' ' . (0.715 - 0.715 * $s) . ' ' . (0.072 - 0.072 * $s) . ' '
+                . (0.213 - 0.213 * $s) . ' ' . (0.715 + 0.285 * $s) . ' ' . (0.072 - 0.072 * $s) . ' '
+                . (0.213 - 0.213 * $s) . ' ' . (0.715 - 0.715 * $s) . ' ' . (0.072 + 0.928 * $s),
         ]);
     }
 }

--- a/src/php/File/GifFile.php
+++ b/src/php/File/GifFile.php
@@ -6,16 +6,17 @@ use pastuhov\Command\Command;
 
 class GifFile extends File implements FileInterface
 {
-    public function crop($srcPath, $destPath, $method, $coords, $rotation)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast)
     {
         $dim = $coords['width'] . 'x' . $coords['height'] . '+' . $coords['x'] .'+' . $coords['y'] . '!';
 
         $rotate = $rotation ? '-rotate ' . intval($rotation) . ' +repage' : '';
 
-        Command::exec('convert {src} ' . $rotate . ' -crop {dim} {dest}', [
+        Command::exec('convert {src} ' . $rotate . ' -crop {dim} -channel RGB -brightness-contrast {bc} {dest}', [
             'src' => $srcPath,
             'dest' => $destPath,
             'dim' => $dim,
+            'bc' => $brightness . 'x' . $contrast,
         ]);
     }
 }

--- a/src/php/File/JpegFile.php
+++ b/src/php/File/JpegFile.php
@@ -44,15 +44,15 @@ class JpegFile extends File implements FileInterface
         ];
     }
 
-    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast, $saturation)
     {
         if ($method === 'precise') {
-            parent::crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast);
+            parent::crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast, $saturation);
             return;
         }
 
-        if ($brightness != 0 || $contrast != 0) {
-            throw new \RuntimeException('Brightness/contrast not supported for lossless crop.');
+        if ($brightness != 0 || $contrast != 0 || $saturation != 0) {
+            throw new \RuntimeException('Filters not supported for lossless crop.');
         }
 
         // Lossless

--- a/src/php/File/JpegFile.php
+++ b/src/php/File/JpegFile.php
@@ -44,11 +44,15 @@ class JpegFile extends File implements FileInterface
         ];
     }
 
-    public function crop($srcPath, $destPath, $method, $coords, $rotation)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast)
     {
         if ($method === 'precise') {
-            parent::crop($srcPath, $destPath, $method, $coords, $rotation);
+            parent::crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast);
             return;
+        }
+
+        if ($brightness != 0 || $contrast != 0) {
+            throw new \RuntimeException('Brightness/contrast not supported for lossless crop.');
         }
 
         // Lossless

--- a/src/php/File/SvgFile.php
+++ b/src/php/File/SvgFile.php
@@ -137,13 +137,13 @@ class SvgFile extends File implements FileInterface
         ];
     }
 
-    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast, $saturation)
     {
         if ( (int)$rotation !== 0 ) {
            throw new RuntimeException( "Rotation not supported for SVGs" );
         }
-        if ($brightness != 0 || $contrast != 0) {
-           throw new RuntimeException( "Brightness/contrast not supported for SVGs" );
+        if ($brightness != 0 || $contrast != 0 || $saturation != 0) {
+           throw new RuntimeException( "Filters not supported for SVGs" );
         }
 
         $metadata = self::readMetadata( $srcPath );

--- a/src/php/File/SvgFile.php
+++ b/src/php/File/SvgFile.php
@@ -137,10 +137,13 @@ class SvgFile extends File implements FileInterface
         ];
     }
 
-    public function crop($srcPath, $destPath, $method, $coords, $rotation)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation, $brightness, $contrast)
     {
         if ( (int)$rotation !== 0 ) {
            throw new RuntimeException( "Rotation not supported for SVGs" );
+        }
+        if ($brightness != 0 || $contrast != 0) {
+           throw new RuntimeException( "Brightness/contrast not supported for SVGs" );
         }
 
         $metadata = self::readMetadata( $srcPath );
@@ -202,6 +205,10 @@ class SvgFile extends File implements FileInterface
     }
 
     public function supportsRotation() {
+        return false;
+    }
+
+    public function supportsFilters() {
         return false;
     }
 }

--- a/src/php/Image.php
+++ b/src/php/Image.php
@@ -170,9 +170,10 @@ class Image
      * @param $rotation
      * @param $brightness
      * @param $contrast
+     * @param $saturation
      * @return Image
      */
-    public function crop($destPath, $method, $x, $y, $width, $height, $rotation, $brightness, $contrast)
+    public function crop($destPath, $method, $x, $y, $width, $height, $rotation, $brightness, $contrast, $saturation)
     {
         if (file_exists($destPath)) {
             unlink($destPath);
@@ -181,7 +182,7 @@ class Image
         // Get coords orientated in the same direction as the image:
         $coords = $this->getCropCoordinates($x, $y, $width, $height, $rotation);
 
-        $this->file->crop($this->path, $destPath, $method, $coords, $rotation, $brightness, $contrast);
+        $this->file->crop($this->path, $destPath, $method, $coords, $rotation, $brightness, $contrast, $saturation);
 
         chmod($destPath, $this->filePermission);
 

--- a/src/php/Image.php
+++ b/src/php/Image.php
@@ -168,9 +168,11 @@ class Image
      * @param $width
      * @param $height
      * @param $rotation
+     * @param $brightness
+     * @param $contrast
      * @return Image
      */
-    public function crop($destPath, $method, $x, $y, $width, $height, $rotation)
+    public function crop($destPath, $method, $x, $y, $width, $height, $rotation, $brightness, $contrast)
     {
         if (file_exists($destPath)) {
             unlink($destPath);
@@ -179,7 +181,7 @@ class Image
         // Get coords orientated in the same direction as the image:
         $coords = $this->getCropCoordinates($x, $y, $width, $height, $rotation);
 
-        $this->file->crop($this->path, $destPath, $method, $coords, $rotation);
+        $this->file->crop($this->path, $destPath, $method, $coords, $rotation, $brightness, $contrast);
 
         chmod($destPath, $this->filePermission);
 


### PR DESCRIPTION
This patch adds support for a few new filters to CropTool, those being brightness, contrast, and saturation. 

## Rationale

These kinds of filters were requested in wish [W298](https://meta.wikimedia.org/wiki/Community_Wishlist/W298) on Meta-Wiki since some users of CropTool also need to apply these filters to images they crop. Having this supported in CropTool allows users to apply these filters easily from Commons instead of loading images into another program like GIMP if they need to make minor adjustments to the image.

## Limitations

These filters only show up for image types that can support them. Those include rasterized images such PNG, JPG, WebP, GIF, etc. The filters can't be applied to JPG files if lossless mode is enabled as jpegtran doesn't support this (nor could it). These new filters also don't work for SVG files.

## Changes

* Added inputs for brightness, contrast, and saturation (numerical like existing inputs)
  * These inputs render conditionally based on the return value of `supportsFilters` and `cropmethod`
* Added a way to preview filters using Cropper
  * An SVG `<filter>` is used along with feComponentTransfer and feColorMatrix so the Cropper preview matches ImageMagick as closely as possible
  * This live preview is pretty close to what the server creates but not 100% accurate, and as before the "Preview" button will show what the server actually creates before the user uploads the image
* Added support for brightness, contrast, and saturation filters in the backend
  * Saturation uses `colorMatrixImage` with the same coefficients as browsers as defined in the W3 filter effects spec:
    * [9.6. Filter primitive feColorMatrix](https://www.w3.org/TR/filter-effects-1/#feColorMatrixElement)
* Removed the `.cropper-face` background overlay so the filter preview isn't tinted by Cropper's selection highlight